### PR TITLE
Add Muut comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ paginate = 10
 copyright = "© 2016 Copyright Text"
 canonifyurls = true
 googleAnalytics = "Your Tracking Id" # optional
+muut = "Your Muut community name" # optional
 
 # optional
 [[menu.header]]
@@ -74,6 +75,7 @@ title = "my new post"
 date = "2016-09-01"
 tags = ["x", "y"]
 categories = ["x", "y"]
+comments = "true", "false" # optional
 +++
 
 content here

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,6 +18,13 @@
   {{ .Content }}
 </div>
 {{ if eq .Type "post" }}
+  {{ if .Site.Params.muut }}
+    {{ if not (eq .Params.comments false) }}
+      <br/>
+      <a class="muut" href="https://muut.com/i/{{ . }}/comments" type="dynamic">{{ .Title }}</a>
+	  <script src="//cdn.muut.com/1/moot.min.js"></script>
+	{{ end }}
+  {{ end }}
   <br/><br/>
   <div class="pagination">
     {{ if .Prev }}<a class="prev" href="{{ .Prev.Permalink }}">{{ .Prev.Title }}</a>{{ else }}<a></a>{{ end }}


### PR DESCRIPTION
Muut comments are added to the bottom of `.post`s if the user has
included a Muut community name parameter in `config.toml`. Comments can
be disabled from individual posts by putting `comments = false` in the
frontmatter.
