### PR TITLE
add default title and date

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,4 +1,6 @@
 +++
-tags=[]
-categories=[]
+title = ""
+date = ""
+tags = []
+categories = []
 +++


### PR DESCRIPTION
Remove annoying warning below:

> WARNING: date and/or title missing from archetype file ".../themes/amp/archetypes/default.md".
> From Hugo 0.24 this must be provided in the archetype file itself, if needed. Example:
> ---
> title: "{{ replace .TranslationBaseName "-" " " | title }}"
> date: {{ .Date }}
> draft: true
> ---